### PR TITLE
feat(*): Add browser API polyfill & typings, configure vendor chunk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6430,6 +6430,17 @@
                 "neo-async": "2.5.0"
             }
         },
+        "web-ext-types": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/web-ext-types/-/web-ext-types-2.0.1.tgz",
+            "integrity": "sha512-7kRibFwyyM4rzIBr50ZC0OuOTSlPDWY/+kpwM1i1DCIasPLc7kEuRnui7zsdLIciqB4cx1AnxUgUf9sG8nSs8A==",
+            "dev": true
+        },
+        "webextension-polyfill": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.2.1.tgz",
+            "integrity": "sha1-zfyRJgMwOfFxNVMVfTW+/x1Nb0o="
+        },
         "webpack": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,15 @@
         "build": "webpack --mode production",
         "serve": "webpack --mode development --watch"
     },
-    "dependencies": {},
+    "dependencies": {
+        "webextension-polyfill": "0.2.x"
+    },
     "devDependencies": {
         "clean-webpack-plugin": "0.1.x",
         "copy-webpack-plugin": "4.5.x",
         "ts-loader": "4.1.x",
         "typescript": "2.8.x",
+        "web-ext-types": "2.0.x",
         "webpack": "4.5.x",
         "webpack-cli": "2.0.x"
     }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,3 +1,5 @@
 // Background
 
 console.log( 'RUNNING BACKGROUND!' );
+
+console.log( browser );

--- a/src/content_script/index.ts
+++ b/src/content_script/index.ts
@@ -1,1 +1,5 @@
 // Content Script
+
+console.log( 'CONTENT SCRIPT RUNNING' );
+
+console.log( browser );

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,6 +8,7 @@
     ],
     "background": {
         "scripts": [
+            "src/vendor.js",
             "src/background.js"
         ],
         "persistent": false
@@ -18,6 +19,7 @@
                 "https://github.com/*/pull/*"
             ],
             "js": [
+                "src/vendor.js",
                 "src/content_script.js"
             ]
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
     "compilerOptions": {
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es6"
+        "target": "es6",
+        "typeRoots": [
+            "node_modules/@types",
+            "node_modules/web-ext-types"
+        ]
     },
     "exclude": [
         "node_modules"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require( 'path' );
 
+const webpack = require( 'webpack' );
 const CleanWebpackPlugin = require( 'clean-webpack-plugin' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' )
 
@@ -37,6 +38,22 @@ module.exports = {
                 from: path.resolve( 'src', 'manifest.json' ),
                 to: path.resolve( 'dist' )
             }
-        ] )
-    ]
+        ] ),
+        new webpack.ProvidePlugin( {
+            browser: 'webextension-polyfill'
+        } )
+    ],
+    optimization: {
+        splitChunks: {
+            cacheGroups: {
+                default: false,
+                commons: {
+                    test: /node_modules/,
+                    name: 'vendor',
+                    chunks: 'initial',
+                    minSize: 1
+                }
+            }
+        }
+    }
 };


### PR DESCRIPTION
- Add Web Extension PI polyfill (https://github.com/mozilla/webextension-polyfill)
- Add Web Extension TypeScript typings (https://github.com/kelseasy/web-ext-types)
- Configure Webpack to produce vendor chunk
- Add vendor chunk to manifest file