### PR TITLE
Make sure all links to GitHub pulls are working

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -62,7 +62,7 @@ export class ExtensionBackground {
      * @returns     - Flag, describing whether the URL is or is not a GitHub Pull Request URL
      */
     private isGithubPullRequestUrl( url: string ): boolean {
-        return /^https:\/\/github\.com\/.+\/.+\/pull\/\d+$/.test( url );
+        return /^https:\/\/github\.com\/.+\/.+\/pull\/\d+/.test( url );
     }
 
 }


### PR DESCRIPTION
We only need to be sure it starts with this URL. All other content (like hash-content) can be "ignored". Note: I have not tested this, it is a GitHub edit.

Fixes #17 