### PR TITLE
fix(background): Loosen GitHub PR URL regular expression, now allowing hash-based additions

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -62,7 +62,7 @@ export class ExtensionBackground {
      * @returns     - Flag, describing whether the URL is or is not a GitHub Pull Request URL
      */
     private isGithubPullRequestUrl( url: string ): boolean {
-        return /^https:\/\/github\.com\/.+\/.+\/pull\/\d+$/.test( url );
+        return /^https:\/\/github\.com\/.+\/.+\/pull\/\d+/.test( url );
     }
 
 }


### PR DESCRIPTION
- Loosen GitHub PR URL regular expression, now allowing hash-based additions

Closes #17.