### PR TITLE
chore(ci): Re-enable npm publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,10 @@ jobs:
         # Publish the dist folder
         - cd dist
       deploy:
-        - provider: npm
-          email: dominique.m.mueller@gmail.com
-          api_key: "$NPM_TOKEN"
-          skip_cleanup: true
+        provider: npm
+        email: dominique.m.mueller@gmail.com
+        api_key: "$NPM_TOKEN"
+        skip_cleanup: true
       after_deploy:
         - cd ..
         - npm run publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,13 @@ jobs:
         - echo "https://$GH_TOKEN:@github.com" > .git/credentials;
         # Do release
         - npm run release
+        # Publish the dist folder
+        - cd dist
       deploy:
-        - provider: script
+        - provider: npm
+          email: dominique.m.mueller@gmail.com
+          api_key: "$NPM_TOKEN"
           skip_cleanup: true
-          script: npm run publish
+      after_deploy:
+        - cd ..
+        - npm run publish

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 **Web Extension enhancing the Travis CI status on GitHub pull request pages.**
 
+[![npm version](https://img.shields.io/npm/v/web-extension-github-travis-status.svg?maxAge=3600&style=flat)](https://www.npmjs.com/package/web-extension-github-travis-status)
 [![dependency status](https://img.shields.io/david/dominique-mueller/web-extension-github-travis-status.svg?maxAge=3600&style=flat)](https://david-dm.org/dominique-mueller/web-extension-github-travis-status)
 [![travis ci build status](https://img.shields.io/travis/dominique-mueller/web-extension-github-travis-status/master.svg?maxAge=3600&style=flat)](https://travis-ci.org/dominique-mueller/web-extension-github-travis-status)
 [![license](https://img.shields.io/npm/l/web-extension-github-travis-status.svg?maxAge=3600&style=flat)](https://github.com/dominique-mueller/web-extension-github-travis-status/LICENSE)


### PR DESCRIPTION
After having a few issues and an accidental npm publishment, things seem to work again. Thus, we re-enable npm publishment for the next version (1.1.1 will be lost forver).